### PR TITLE
use boot-bin binary; upgrade to 2.6.0

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -51,13 +51,13 @@ fi
 
 export BOOT_LOCAL_REPO="$cache/.m2/repository"
 export BOOT_JVM_OPTIONS="-Xmx768m -Xss512k"
-export BOOT_VERSION=${BOOT_VERSION:-2.2.0}
+export BOOT_VERSION=${BOOT_VERSION:-2.6.0}
 
 if [[ -f "$cache/boot" ]]; then
     echo "-----> Using cached version of boot"
 else
     echo -n "-----> Downloading boot..."
-    curl --show-error -sLo "$cache/boot.sh" https://github.com/boot-clj/boot/releases/download/$BOOT_VERSION/boot.sh
+    curl --show-error -sLo "$cache/boot.sh" https://github.com/boot-clj/boot-bin/releases/download/2.5.2/boot.sh
     chmod +x "$cache/boot.sh"
     echo " done"
     echo "-----> Bootstrapping..."


### PR DESCRIPTION
Fetches binaries from new `boot-bin` project. Note that binaries are now (since 2.4.2 I think) generally backwards compatible so fetching `latest` would be ok. We're fetching 2.5.2 here anyways just to be conservative. 

Any setting of `BOOT_VERSION` will be respected and is expected to work down to at least `2.2.0`
