### PR TITLE
allow things to run as root

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -61,6 +61,7 @@ else
     chmod +x "$cache/boot.sh"
     echo " done"
     echo "-----> Bootstrapping..."
+    export BOOT_AS_ROOT=yes
     "$cache/boot.sh" -C help 2>&1 | grep Retrieving | indent
     "$cache/boot.sh" -C -V 2>&1 | indent
     mv "$cache/boot.sh" "$cache/boot"


### PR DESCRIPTION
via #9 

When running newer versions of Boot as root it will throw an error. Since running as root is the default inside dokku setting this value to true as a default seems right.
