### PR TITLE
Exclude ~/.m2

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -68,7 +68,7 @@ export BOOT_HOME="$cached_boot_home_dir"
 export BOOT_LOCAL_REPO="$cached_m2_dir/repository"
 export BOOT_JVM_OPTIONS="-Xmx768m -Xss512k"
 export BOOT_SH_VERSION=${BOOT_SH_VERSION:-2.5.2}
-export BOOT_VERSION=${BOOT_VERSION:-2.6.0}
+export BOOT_VERSION=${BOOT_VERSION:-2.7.0}
 
 if [[ -f "$cache/boot" ]]; then
     echo "-----> Using cached version of boot"

--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ echo "done"
 
 if [[ -d "$env_dir" ]]; then
     # load the buildpack config vars
-    for key in BOOT_SH_VERSION BOOT_VERSION BOOTBUILD_CMD BOOTBUILD_CONFIG_WHITELIST; do
+    for key in BOOT_SH_VERSION BOOT_VERSION BOOTBUILD_CMD BOOTBUILD_EXCLUDE_M2 BOOTBUILD_CONFIG_WHITELIST; do
         if [[ -f "$env_dir/$key" ]]; then
             export "$key=$(cat "$env_dir/$key")"
         fi
@@ -116,7 +116,10 @@ echo "-----> Running: $boot_cmd"
 
 echo -n "-----> Copying boot artifacts..."
 rm -rf "$cached_boot_home_dir/cache/cache" "$cached_boot_home_dir/cache/tmp"
-cp -R "$cached_m2_dir" "$build/.m2"
+if [[ -z "$BOOTBUILD_EXCLUDE_M2" ]]
+then
+  cp -R "$cached_m2_dir" "$build/.m2"
+ fi
 cp -R "$cached_boot_home_dir" "$build/.boot"
 echo " done"
 


### PR DESCRIPTION
We ran into Heroku slug size issues but the current `exclude-m2` branch is broken and, since it is conditional exclusion, it might make sense for the feature to be in master.

Based on https://github.com/upworthy/heroku-buildpack-boot/commit/fdc6c899727a1d8ac124e7a5a03dcbdeaf55e1ee and https://github.com/upworthy/heroku-buildpack-boot/issues/7
